### PR TITLE
feat(#26): define shared domain event contracts with serialization tests

### DIFF
--- a/esfl/shared-contracts/pom.xml
+++ b/esfl/shared-contracts/pom.xml
@@ -15,6 +15,12 @@
 	<description>Shared DTOs and event contracts module</description>
 
 	<dependencies>
+		<!-- Jackson Annotations -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+		</dependency>
+
 		<!-- Lombok – compile-time only annotation processing -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -22,10 +28,29 @@
 			<optional>true</optional>
 		</dependency>
 
+		<!-- Jackson Databind for testing -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- JUnit 5 for unit testing -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		
+		<!-- AssertJ for assertions -->
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -44,6 +69,47 @@
 						</path>
 					</annotationProcessorPaths>
 				</configuration>
+			</plugin>
+			<!-- JaCoCo test coverage -->
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.11</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>check-coverage</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<limits>
+										<limit>
+											<counter>INSTRUCTION</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>1.00</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/AccountClosed.java
+++ b/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/AccountClosed.java
@@ -1,16 +1,20 @@
 package com.ledger.financial.sourced.event.contracts;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.Instant;
 import java.util.UUID;
 
 public record AccountClosed(
-        UUID eventId,
-        String eventType,
-        UUID aggregateId,
-        int aggregateVersion,
-        Instant occurredAt,
-        int schemaVersion
+        @JsonProperty("eventId") UUID eventId,
+        @JsonProperty("eventType") String eventType,
+        @JsonProperty("aggregateId") UUID aggregateId,
+        @JsonProperty("aggregateVersion") int aggregateVersion,
+        @JsonProperty("occurredAt") Instant occurredAt,
+        @JsonProperty("schemaVersion") int schemaVersion
 ) implements DomainEvent {
+    @JsonCreator
     public AccountClosed {
         if (eventType == null) eventType = "AccountClosed";
         if (schemaVersion == 0) schemaVersion = 1;

--- a/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/AccountCreated.java
+++ b/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/AccountCreated.java
@@ -3,16 +3,20 @@ package com.ledger.financial.sourced.event.contracts;
 import java.time.Instant;
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record AccountCreated(
-        UUID eventId,
-        String eventType,
-        UUID aggregateId,
-        int aggregateVersion,
-        Instant occurredAt,
-        int schemaVersion,
-        UUID ownerId,
-        String currency
+        @JsonProperty("eventId") UUID eventId,
+        @JsonProperty("eventType") String eventType,
+        @JsonProperty("aggregateId") UUID aggregateId,
+        @JsonProperty("aggregateVersion") int aggregateVersion,
+        @JsonProperty("occurredAt") Instant occurredAt,
+        @JsonProperty("schemaVersion") int schemaVersion,
+        @JsonProperty("ownerId") UUID ownerId,
+        @JsonProperty("currency") String currency
 ) implements DomainEvent {
+    @JsonCreator
     public AccountCreated {
         if (eventType == null) eventType = "AccountCreated";
         if (schemaVersion == 0) schemaVersion = 1;

--- a/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/DomainEvent.java
+++ b/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/DomainEvent.java
@@ -3,7 +3,28 @@ package com.ledger.financial.sourced.event.contracts;
 import java.time.Instant;
 import java.util.UUID;
 
-public interface DomainEvent {
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME, 
+    include = JsonTypeInfo.As.EXISTING_PROPERTY, 
+    property = "eventType", 
+    visible = true
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = AccountCreated.class, name = "AccountCreated"),
+    @JsonSubTypes.Type(value = FundsDeposited.class, name = "FundsDeposited"),
+    @JsonSubTypes.Type(value = FundsWithdrawn.class, name = "FundsWithdrawn"),
+    @JsonSubTypes.Type(value = FundsDebited.class, name = "FundsDebited"),
+    @JsonSubTypes.Type(value = FundsCredited.class, name = "FundsCredited"),
+    @JsonSubTypes.Type(value = FundsRefunded.class, name = "FundsRefunded"),
+    @JsonSubTypes.Type(value = AccountClosed.class, name = "AccountClosed"),
+    @JsonSubTypes.Type(value = AccountSuspended.class, name = "AccountSuspended")
+})
+public sealed interface DomainEvent permits 
+    AccountCreated, FundsDeposited, FundsWithdrawn, FundsDebited, FundsCredited, FundsRefunded, AccountClosed, AccountSuspended {
+    
     UUID eventId();
     String eventType();
     UUID aggregateId();

--- a/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/FundsCredited.java
+++ b/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/FundsCredited.java
@@ -6,17 +6,19 @@ import java.util.UUID;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record AccountSuspended(
+public record FundsCredited(
         @JsonProperty("eventId") UUID eventId,
         @JsonProperty("eventType") String eventType,
         @JsonProperty("aggregateId") UUID aggregateId,
         @JsonProperty("aggregateVersion") int aggregateVersion,
         @JsonProperty("occurredAt") Instant occurredAt,
-        @JsonProperty("schemaVersion") int schemaVersion
+        @JsonProperty("schemaVersion") int schemaVersion,
+        @JsonProperty("amount") long amount,
+        @JsonProperty("transactionId") UUID transactionId
 ) implements DomainEvent {
     @JsonCreator
-    public AccountSuspended {
-        if (eventType == null) eventType = "AccountSuspended";
+    public FundsCredited {
+        if (eventType == null) eventType = "FundsCredited";
         if (schemaVersion == 0) schemaVersion = 1;
     }
 }

--- a/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/FundsDebited.java
+++ b/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/FundsDebited.java
@@ -6,17 +6,19 @@ import java.util.UUID;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record AccountSuspended(
+public record FundsDebited(
         @JsonProperty("eventId") UUID eventId,
         @JsonProperty("eventType") String eventType,
         @JsonProperty("aggregateId") UUID aggregateId,
         @JsonProperty("aggregateVersion") int aggregateVersion,
         @JsonProperty("occurredAt") Instant occurredAt,
-        @JsonProperty("schemaVersion") int schemaVersion
+        @JsonProperty("schemaVersion") int schemaVersion,
+        @JsonProperty("amount") long amount,
+        @JsonProperty("transactionId") UUID transactionId
 ) implements DomainEvent {
     @JsonCreator
-    public AccountSuspended {
-        if (eventType == null) eventType = "AccountSuspended";
+    public FundsDebited {
+        if (eventType == null) eventType = "FundsDebited";
         if (schemaVersion == 0) schemaVersion = 1;
     }
 }

--- a/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/FundsDeposited.java
+++ b/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/FundsDeposited.java
@@ -3,16 +3,20 @@ package com.ledger.financial.sourced.event.contracts;
 import java.time.Instant;
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record FundsDeposited(
-        UUID eventId,
-        String eventType,
-        UUID aggregateId,
-        int aggregateVersion,
-        Instant occurredAt,
-        int schemaVersion,
-        long amount,
-        UUID transactionId
+        @JsonProperty("eventId") UUID eventId,
+        @JsonProperty("eventType") String eventType,
+        @JsonProperty("aggregateId") UUID aggregateId,
+        @JsonProperty("aggregateVersion") int aggregateVersion,
+        @JsonProperty("occurredAt") Instant occurredAt,
+        @JsonProperty("schemaVersion") int schemaVersion,
+        @JsonProperty("amount") long amount,
+        @JsonProperty("transactionId") UUID transactionId
 ) implements DomainEvent {
+    @JsonCreator
     public FundsDeposited {
         if (eventType == null) eventType = "FundsDeposited";
         if (schemaVersion == 0) schemaVersion = 1;

--- a/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/FundsRefunded.java
+++ b/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/FundsRefunded.java
@@ -6,17 +6,20 @@ import java.util.UUID;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record AccountSuspended(
+public record FundsRefunded(
         @JsonProperty("eventId") UUID eventId,
         @JsonProperty("eventType") String eventType,
         @JsonProperty("aggregateId") UUID aggregateId,
         @JsonProperty("aggregateVersion") int aggregateVersion,
         @JsonProperty("occurredAt") Instant occurredAt,
-        @JsonProperty("schemaVersion") int schemaVersion
+        @JsonProperty("schemaVersion") int schemaVersion,
+        @JsonProperty("amount") long amount,
+        @JsonProperty("transactionId") UUID transactionId,
+        @JsonProperty("originalTransactionId") UUID originalTransactionId
 ) implements DomainEvent {
     @JsonCreator
-    public AccountSuspended {
-        if (eventType == null) eventType = "AccountSuspended";
+    public FundsRefunded {
+        if (eventType == null) eventType = "FundsRefunded";
         if (schemaVersion == 0) schemaVersion = 1;
     }
 }

--- a/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/FundsWithdrawn.java
+++ b/esfl/shared-contracts/src/main/java/com/ledger/financial/sourced/event/contracts/FundsWithdrawn.java
@@ -3,16 +3,20 @@ package com.ledger.financial.sourced.event.contracts;
 import java.time.Instant;
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record FundsWithdrawn(
-        UUID eventId,
-        String eventType,
-        UUID aggregateId,
-        int aggregateVersion,
-        Instant occurredAt,
-        int schemaVersion,
-        long amount,
-        UUID transactionId
+        @JsonProperty("eventId") UUID eventId,
+        @JsonProperty("eventType") String eventType,
+        @JsonProperty("aggregateId") UUID aggregateId,
+        @JsonProperty("aggregateVersion") int aggregateVersion,
+        @JsonProperty("occurredAt") Instant occurredAt,
+        @JsonProperty("schemaVersion") int schemaVersion,
+        @JsonProperty("amount") long amount,
+        @JsonProperty("transactionId") UUID transactionId
 ) implements DomainEvent {
+    @JsonCreator
     public FundsWithdrawn {
         if (eventType == null) eventType = "FundsWithdrawn";
         if (schemaVersion == 0) schemaVersion = 1;

--- a/esfl/shared-contracts/src/test/java/com/ledger/financial/sourced/event/contracts/DomainEventSerializationTest.java
+++ b/esfl/shared-contracts/src/test/java/com/ledger/financial/sourced/event/contracts/DomainEventSerializationTest.java
@@ -1,0 +1,169 @@
+package com.ledger.financial.sourced.event.contracts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+class DomainEventSerializationTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    @Test
+    void testAccountCreatedSerialization() throws Exception {
+        AccountCreated event = new AccountCreated(
+                UUID.randomUUID(),
+                null,
+                UUID.randomUUID(),
+                1,
+                Instant.now(),
+                0,
+                UUID.randomUUID(),
+                "USD"
+        );
+        verifySerialization(event);
+    }
+
+    @Test
+    void testFundsDepositedSerialization() throws Exception {
+        FundsDeposited event = new FundsDeposited(
+                UUID.randomUUID(),
+                null,
+                UUID.randomUUID(),
+                2,
+                Instant.now(),
+                0,
+                1000L,
+                UUID.randomUUID()
+        );
+        verifySerialization(event);
+    }
+
+    @Test
+    void testFundsWithdrawnSerialization() throws Exception {
+        FundsWithdrawn event = new FundsWithdrawn(
+                UUID.randomUUID(),
+                null,
+                UUID.randomUUID(),
+                3,
+                Instant.now(),
+                0,
+                500L,
+                UUID.randomUUID()
+        );
+        verifySerialization(event);
+    }
+
+    @Test
+    void testFundsDebitedSerialization() throws Exception {
+        FundsDebited event = new FundsDebited(
+                UUID.randomUUID(),
+                null,
+                UUID.randomUUID(),
+                4,
+                Instant.now(),
+                0,
+                200L,
+                UUID.randomUUID()
+        );
+        verifySerialization(event);
+    }
+
+    @Test
+    void testFundsCreditedSerialization() throws Exception {
+        FundsCredited event = new FundsCredited(
+                UUID.randomUUID(),
+                null,
+                UUID.randomUUID(),
+                5,
+                Instant.now(),
+                0,
+                300L,
+                UUID.randomUUID()
+        );
+        verifySerialization(event);
+    }
+
+    @Test
+    void testFundsRefundedSerialization() throws Exception {
+        FundsRefunded event = new FundsRefunded(
+                UUID.randomUUID(),
+                null,
+                UUID.randomUUID(),
+                6,
+                Instant.now(),
+                0,
+                100L,
+                UUID.randomUUID(),
+                UUID.randomUUID()
+        );
+        verifySerialization(event);
+    }
+
+    @Test
+    void testAccountClosedSerialization() throws Exception {
+        AccountClosed event = new AccountClosed(
+                UUID.randomUUID(),
+                null,
+                UUID.randomUUID(),
+                7,
+                Instant.now(),
+                0
+        );
+        verifySerialization(event);
+    }
+
+    @Test
+    void testAccountSuspendedSerialization() throws Exception {
+        AccountSuspended event = new AccountSuspended(
+                UUID.randomUUID(),
+                null,
+                UUID.randomUUID(),
+                8,
+                Instant.now(),
+                0
+        );
+        verifySerialization(event);
+    }
+
+    @Test
+    void testPolymorphicDeserialization() throws Exception {
+        AccountCreated event = new AccountCreated(
+                UUID.randomUUID(),
+                null,
+                UUID.randomUUID(),
+                1,
+                Instant.now(),
+                0,
+                UUID.randomUUID(),
+                "GBP"
+        );
+        
+        String json = objectMapper.writeValueAsString(event);
+        DomainEvent deserialized = objectMapper.readValue(json, DomainEvent.class);
+        
+        assertThat(deserialized).isInstanceOf(AccountCreated.class);
+        assertThat(deserialized.eventId()).isEqualTo(event.eventId());
+        assertThat(deserialized.schemaVersion()).isEqualTo(1);
+    }
+
+    private void verifySerialization(DomainEvent original) throws Exception {
+        String json = objectMapper.writeValueAsString(original);
+        DomainEvent deserialized = objectMapper.readValue(json, original.getClass());
+
+        assertThat(deserialized).isEqualTo(original);
+        assertThat(deserialized.schemaVersion()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
- Define DomainEvent as a sealed interface with Jackson polymorphic type info.
- Implement immutable records for all 8 domain events.
- Annotate records with @JsonCreator and @JsonProperty for Jackson support.
- Add DomainEventSerializationTest to verify round-trip JSON serialization.
- Configure JaCoCo code coverage plugin for shared-contracts at 100% threshold.
close #26 